### PR TITLE
"PLUGINWIZARD-171 : Use javax API instead of hibernate API for annotation @notempty"

### DIFF
--- a/webapp/WEB-INF/templates/generators/default/business/gt_business_class.html
+++ b/webapp/WEB-INF/templates/generators/default/business/gt_business_class.html
@@ -52,7 +52,7 @@ package fr.paris.lutece.plugins.${radical_package}.business;
 </#list>
 <#if hasString?? && hasString>
 import javax.validation.constraints.Size;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 </#if>
 <#if hasURL?? && hasURL>
 import org.hibernate.validator.constraints.URL;


### PR DESCRIPTION
Replaced com.hibernate.validator.constraints.NotEmpty (depreciated) with javax.validation.constraints.NotEmpty.